### PR TITLE
Experiment/thread affinity

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -229,8 +229,6 @@
                                 <includes>
                                     <include>com.fasterxml.jackson.core:jackson-core</include>
                                     <include>org.snakeyaml:snakeyaml-engine</include>
-                                    <include>net.openhft:affinity</include>
-                                    <include>org.slf4j:slf4j-api</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -385,6 +383,8 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.api.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -229,6 +229,8 @@
                                 <includes>
                                     <include>com.fasterxml.jackson.core:jackson-core</include>
                                     <include>org.snakeyaml:snakeyaml-engine</include>
+                                    <include>net.openhft:affinity</include>
+                                    <include>org.slf4j:slf4j-api</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -383,8 +385,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.api.version}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -76,6 +76,9 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
     public static final String URI_CP_MEMBERS_URL = URI_CP_SUBSYSTEM_BASE_URL + "/members";
     public static final String URI_LOCAL_CP_MEMBER_URL = URI_CP_MEMBERS_URL + "/local";
 
+
+    public static final String URI_SET_CPU_AFFINITY = "/hazelcast/rest/setCpuAffinity";
+
     protected HttpCommandProcessor(TextCommandService textCommandService) {
         super(textCommandService);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -78,6 +78,7 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
 
 
     public static final String URI_SET_CPU_AFFINITY = "/hazelcast/rest/setCpuAffinity";
+    public static final String URI_SET_ADAPTIVE_THREAD_SIZING = "/hazelcast/rest/setAdaptivePartitionThreadSizing";
 
     protected HttpCommandProcessor(TextCommandService textCommandService) {
         super(textCommandService);

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -926,7 +926,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         if (strList.length != 1) {
             return;
         }
-        logger.info("Got thread affinity configuration change request:" + strList);
+        logger.info("Got thread affinity configuration change request: " + strList[0]);
 
         // TODO
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -125,6 +125,8 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                 sendResponse = false;
             } else if (uri.startsWith(URI_LICENSE_INFO)) {
                 handleSetLicense(command);
+            } else if (uri.startsWith(URI_SET_CPU_AFFINITY)) {
+                handleSetCpuAffinity(command);
             } else {
                 command.send404();
             }
@@ -913,6 +915,22 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
 
     protected String responseOnSetLicenseSuccess() {
         return response(ResponseType.SUCCESS);
+    }
+
+    private void handleSetCpuAffinity(HttpPostCommand command) {
+        byte[] data = command.getData();
+        if (data == null) {
+            return;
+        }
+        final String[] strList = bytesToString(data).split("&", -1);
+        if (strList.length != 1) {
+            return;
+        }
+        logger.info("Got thread affinity configuration change request:" + strList);
+
+        // TODO
+
+        command.setResponse(HttpCommand.CONTENT_TYPE_JSON, stringToBytes(response(ResponseType.SUCCESS)));
     }
 
 }


### PR DESCRIPTION
* Adds REST API endpoint to change thread affinity dynamically
* Includes missing deps into the artifact

## Dynamic CPU affinity endpoint

```bash
curl -X POST --data "partitionCpus&1,3,5,7" http://127.0.0.1:5701/hazelcast/rest/setCpuAffinity/
```

First argument accepts `partitionCpus` | `ioCpus`.

## Dynamic adaptive partition thread affinity sizing

```bash
curl -X POST --data "true" http://127.0.0.1:5701/hazelcast/rest/setAdaptivePartitionThreadSizing/
```